### PR TITLE
PERF: closed-ref SQL improvements

### DIFF
--- a/q2_vsearch/tests/test_cluster_features.py
+++ b/q2_vsearch/tests/test_cluster_features.py
@@ -470,9 +470,9 @@ class ClusterFeaturesClosedReference(TestPluginBase):
         # feature3 is selected as the rep seq because it has a higher count.
         # Similarly, feature2 is selected as the cluster rep seq  because it
         # has a higher count.
-        exp_matched_seqs = [self.input_sequences_list[1],  # feature2
-                            self.input_sequences_list[2]]  # feature3
-        _relabel_seqs(exp_matched_seqs, ['r2', 'r1'])
+        exp_matched_seqs = [self.input_sequences_list[2],  # feature3
+                            self.input_sequences_list[1]]  # feature2
+        _relabel_seqs(exp_matched_seqs, ['r1', 'r2'])
         self.assertEqual(obs_matched_seqs, exp_matched_seqs)
 
         # all sequences matched, so unmatched seqs is empty
@@ -844,9 +844,9 @@ class PrivateFunctionTests(TestPluginBase):
 
             obs_seqs = _read_seqs(output_sequences_f.name)
         rep_seqs = _read_seqs(self.input_sequences)
-        exp_seqs = [rep_seqs[1],  # feature2
-                    rep_seqs[2]]  # feature3
-        _relabel_seqs(exp_seqs, ['r2', 'r1'])
+        exp_seqs = [rep_seqs[2],  # feature3
+                    rep_seqs[1]]  # feature2
+        _relabel_seqs(exp_seqs, ['r1', 'r2'])
         self.assertEqual(obs_seqs, exp_seqs)
 
     def test_clusters_with_multiple_features_with_same_count(self):


### PR DESCRIPTION
This PR addresses a few issues related to closed-reference clustering. We offload a bunch of data manipulation to sqlite, however there were a few problems:

- table input was a bottleneck in places
- table output was a bottleneck in place
- the query for identifying the representative sequence of a cluster was prone to exploding (due to a cartesian product).

After reviewing the sqlite docs, I discovered that we can rely on some dialect-specific behavior with respect to the aggregate function `MAX` --- basically when finding the max value of a group, sqlite will allow you to bind the bare columns of that query to other aspects of the statement, which allows us to skip the `LEFT OUTER JOIN` _completely_.

I did some psuedo benchmarks, using the ECAM dataset. I gave up at the ~4 hr mark when benchmarking the "before" case (I was producing millions and millions of virtual rows, all destined for deletion, since the query didn't need them). The "after": ~0.5hrs.