### PR TITLE
MAINT: Add --minseqlength 1

### DIFF
--- a/q2_vsearch/_chimera.py
+++ b/q2_vsearch/_chimera.py
@@ -61,7 +61,8 @@ def _uchime_ref(sequences, table, reference_sequences, dn, mindiffs,
                    '--db', str(reference_sequences),
                    '--qmask', 'none',  # ensures no lowercase DNA chars
                    '--xsize',
-                   '--threads', str(threads)]
+                   '--threads', str(threads),
+                   '--minseqlength', '1']
             run_command(cmd)
             # this processing step should be removed, pending fix of:
             # https://github.com/qiime2/q2-vsearch/issues/39
@@ -102,7 +103,8 @@ def _uchime_denovo(sequences, table, dn, mindiffs, mindiv, minh, xn):
                    '--minh', str(minh),
                    '--xn', str(xn),
                    '--qmask', 'none',  # ensures no lowercase DNA chars
-                   '--xsize']
+                   '--xsize',
+                   '--minseqlength', '1']
             run_command(cmd)
             # this processing step should be removed, pending fix of:
             # https://github.com/qiime2/q2-vsearch/issues/39

--- a/q2_vsearch/_cluster_features.py
+++ b/q2_vsearch/_cluster_features.py
@@ -189,7 +189,8 @@ def cluster_features_de_novo(sequences: DNAFASTAFormat, table: biom.Table,
                    '--uc', out_uc.name,
                    '--qmask', 'none',  # ensures no lowercase DNA chars
                    '--xsize',
-                   '--threads', str(threads)]
+                   '--threads', str(threads),
+                   '--minseqlength', '1']
             run_command(cmd)
             out_uc.seek(0)
 
@@ -252,7 +253,8 @@ def cluster_features_closed_reference(sequences: DNAFASTAFormat,
                '--strand', str(strand),
                '--qmask', 'none',  # ensures no lowercase DNA chars
                '--notmatched', tmp_unmatched_seqs.name,
-               '--threads', str(threads)]
+               '--threads', str(threads),
+               '--minseqlength', '1']
         run_command(cmd)
         out_uc.seek(0)
 
@@ -267,7 +269,8 @@ def cluster_features_closed_reference(sequences: DNAFASTAFormat,
             cmd = ['vsearch',
                    '--sortbysize', tmp_unmatched_seqs.name,
                    '--xsize',
-                   '--output', str(unmatched_seqs)]
+                   '--output', str(unmatched_seqs),
+                   '--minseqlength', '1']
             run_command(cmd)
 
         try:

--- a/q2_vsearch/_cluster_sequences.py
+++ b/q2_vsearch/_cluster_sequences.py
@@ -126,7 +126,8 @@ def dereplicate_sequences(sequences: QIIME1DemuxDirFmt,
                '--relabel_sha1', '--relabel_keep',
                '--uc', out_uc.name,
                '--qmask', 'none',
-               '--xsize']
+               '--xsize',
+               '--minseqlength', '1']
         if derep_prefix:
             cmd[1] = '--derep_prefix'
         run_command(cmd)

--- a/q2_vsearch/_join_pairs.py
+++ b/q2_vsearch/_join_pairs.py
@@ -128,7 +128,7 @@ def _join_pairs_w_command_output(
                '--fastq_qminout', str(qminout),
                '--fastq_qmax', str(qmax),
                '--fastq_qmaxout', str(qmaxout),
-               ]
+               '--minseqlength', '1']
         if truncqual is not None:
             cmd += ['--fastq_truncqual', str(truncqual)]
         if maxns is not None:

--- a/q2_vsearch/tests/data/dna-sequences-short.fasta
+++ b/q2_vsearch/tests/data/dna-sequences-short.fasta
@@ -1,0 +1,4 @@
+>feature1
+A
+>feature2
+A

--- a/q2_vsearch/tests/test_cluster_features.py
+++ b/q2_vsearch/tests/test_cluster_features.py
@@ -198,6 +198,28 @@ class ClusterFeaturesDenovoTests(TestPluginBase):
         exp_seqs = [self.input_sequences_list[0]]
         self.assertEqual(obs_seqs, exp_seqs)
 
+    def test_short_sequences(self):
+        input_sequences_fp = self.get_data_path('dna-sequences-short.fasta')
+        input_sequences = DNAFASTAFormat(input_sequences_fp, mode='r')
+
+        input_table = biom.Table(np.array([[0, 1, 3],
+                                           [1, 1, 2]]),
+                                 ['feature1', 'feature2'],
+                                 ['sample1', 'sample2', 'sample3'])
+
+        exp_table = biom.Table(np.array([[1, 2, 5]]),
+                               ['feature1'],
+                               ['sample1', 'sample2', 'sample3'])
+
+        with redirected_stdio(stderr=os.devnull):
+            obs_table, obs_sequences = cluster_features_de_novo(
+                sequences=input_sequences, table=input_table,
+                perc_identity=0.01)
+        # order of identifiers is important for biom.Table equality
+        obs_table = \
+            obs_table.sort_order(exp_table.ids(axis='observation'),
+                                 axis='observation')
+
     def test_extra_features_in_sequences(self):
         input_table = biom.Table(np.array([[0, 1, 3], [1, 1, 2], [4, 5, 6]]),
                                  ['feature1', 'feature2', 'feature3'],
@@ -477,6 +499,31 @@ class ClusterFeaturesClosedReference(TestPluginBase):
 
         # all sequences matched, so unmatched seqs is empty
         self.assertEqual(os.path.getsize(str(unmatched_seqs)), 0)
+
+    def test_short_sequences(self):
+        input_sequences_fp = self.get_data_path('dna-sequences-short.fasta')
+        input_sequences = DNAFASTAFormat(input_sequences_fp, mode='r')
+
+        input_table = biom.Table(np.array([[0, 1, 3],
+                                           [1, 1, 2]]),
+                                 ['feature1', 'feature2'],
+                                 ['sample1', 'sample2', 'sample3'])
+
+        exp_table = biom.Table(np.array([[1, 2, 5]]),
+                               ['r2'],
+                               ['sample1', 'sample2', 'sample3'])
+
+        with redirected_stdio(stderr=os.devnull):
+            obs_table, matched_seqs, unmatched_seqs = \
+                cluster_features_closed_reference(
+                    sequences=input_sequences, table=input_table,
+                    reference_sequences=self.ref_sequences_1,
+                    perc_identity=0.01)
+
+        # order of identifiers is important for biom.Table equality
+        obs_table = \
+            obs_table.sort_order(exp_table.ids(axis='observation'),
+                                 axis='observation')
 
     def test_extra_features_in_sequences(self):
         input_table = biom.Table(np.array([[0, 1, 3], [1, 1, 2], [4, 5, 6]]),


### PR DESCRIPTION
closes #69. All this does right now is add `--minseqlength 1` to the calls to vsearch methods.

Do we need to add new tests for this behavior? Do we need to make any further edits to ensure the behavior we want is actually occuring?
