### PR TITLE
IMP: Remove sample ids from derep seqs sequences

### DIFF
--- a/q2_vsearch/_cluster_sequences.py
+++ b/q2_vsearch/_cluster_sequences.py
@@ -139,4 +139,15 @@ def dereplicate_sequences(sequences: QIIME1DemuxDirFmt,
                                      constructor=skbio.DNA,
                                      format='fasta')}
     table.update_ids(id_map=id_map, axis='observation')
+
+    # Remove sample-id from sequence table
+    lines = '\n' + ''.join([line for line in dereplicated_sequences.open()])
+    fixed_lines = '\n'
+    for line in lines.split('\n'):
+        line = line.split(' ')[0]
+        fixed_lines = fixed_lines + line + '\n'
+
+    with open(str(dereplicated_sequences), 'w') as fh:
+        fh.write(fixed_lines)
+
     return table, dereplicated_sequences

--- a/q2_vsearch/tests/test_cluster_sequences.py
+++ b/q2_vsearch/tests/test_cluster_sequences.py
@@ -50,15 +50,15 @@ class DereplicateSequences(TestPluginBase):
         exp_seqs = [skbio.DNA('AAACGTTACGGTTAACTATACATGCAGAAGACTAATCGG',
                               metadata={'id': ('4574b947a0159c0da35a1f30f'
                                                '989681a1d9f64ef'),
-                                        'description': 'sample1_1'}),
+                                        'description': ''}),
                     skbio.DNA('ACGTACGTACGTACGTACGTACGTACGTACGTGCATGGTGCGACCG',
                               metadata={'id': ('16a1263bde4f2f99422630d1bb'
                                                '87935c4236d1ba'),
-                                        'description': 's2_42'}),
+                                        'description': ''}),
                     skbio.DNA('AAACGTTACGGTTAACTATACATGCAGAAGACTA',
                               metadata={'id': ('1768cf7fca79f84d651b34d878d'
                                                'e2492c6a7b971'),
-                                        'description': 's2_2'})]
+                                        'description': ''})]
         self.assertEqual(obs_seqs, exp_seqs)
 
     def test_dereplicate_sequences_underscores_in_ids(self):
@@ -88,15 +88,15 @@ class DereplicateSequences(TestPluginBase):
         exp_seqs = [skbio.DNA('AAACGTTACGGTTAACTATACATGCAGAAGACTAATCGG',
                               metadata={'id': ('4574b947a0159c0da35a1f30f'
                                                '989681a1d9f64ef'),
-                                        'description': 'sa_mple1_1'}),
+                                        'description': ''}),
                     skbio.DNA('ACGTACGTACGTACGTACGTACGTACGTACGTGCATGGTGCGACCG',
                               metadata={'id': ('16a1263bde4f2f99422630d1bb'
                                                '87935c4236d1ba'),
-                                        'description': 's2_42'}),
+                                        'description': ''}),
                     skbio.DNA('AAACGTTACGGTTAACTATACATGCAGAAGACTA',
                               metadata={'id': ('1768cf7fca79f84d651b34d878d'
                                                'e2492c6a7b971'),
-                                        'description': 's2_2'})]
+                                        'description': ''})]
         self.assertEqual(obs_seqs, exp_seqs)
 
     def test_dereplicate_sequences_prefix(self):
@@ -124,11 +124,11 @@ class DereplicateSequences(TestPluginBase):
         exp_seqs = [skbio.DNA('AAACGTTACGGTTAACTATACATGCAGAAGACTAATCGG',
                               metadata={'id': ('4574b947a0159c0da35a1f30f'
                                                '989681a1d9f64ef'),
-                                        'description': 's2_1'}),
+                                        'description': ''}),
                     skbio.DNA('ACGTACGTACGTACGTACGTACGTACGTACGTGCATGGTGCGACCG',
                               metadata={'id': ('16a1263bde4f2f99422630d1bb'
                                                '87935c4236d1ba'),
-                                        'description': 's2_42'})]
+                                        'description': ''})]
         self.assertEqual(obs_seqs, exp_seqs)
 
 


### PR DESCRIPTION
Closes #57, but we seem to have a problem.

Attempting to use the methods described in #57 (removing the --relabel-keep flag) didn't work. It caused the following.
___
![image](https://user-images.githubusercontent.com/10642616/85619231-d8241300-b616-11ea-8ca6-ad1558b1f9a1.png)
___

Adding `strict=False` causes the table to only have the sample_ids and the sequences to only have the sha
___
![image](https://user-images.githubusercontent.com/10642616/85620343-7f557a00-b618-11ea-8caa-73369759f49c.png)
___

So I took matters into my own hands and decided to manually strip the ids from the completed sequence output. Using the current method we get something that looks like this.
___
![image](https://user-images.githubusercontent.com/10642616/85620638-e96e1f00-b618-11ea-9702-b797e1b03041.png)
___
This caused tests to explode because it looks like skbio wants those sample_ids in the sequences to be used as a description? I am hazy on what exactly is going on with skbio, but I suspect it's the reason we chose to use `--relabel-keep` in the first place, or part of the reason anyway. 