### PR TITLE
MAINT: updates for python 3.10

### DIFF
--- a/q2_vsearch/_stats.py
+++ b/q2_vsearch/_stats.py
@@ -30,8 +30,9 @@ def _get_stats_easy(cmds_packed) -> None:
     with fileinput.input(files=filelist, mode='r',
                          openhook=fileinput.hook_compressed) as fh:
         for line in fh:
+            encoded_line = line.encode('utf-8')
             for p in processes:
-                p.stdin.write(line)
+                p.stdin.write(encoded_line)
 
     for p in processes:
         p.stdin.close()


### PR DESCRIPTION
Looks like `stdin.write` now expects a bytes-like object in python 3.10.
Paired PR with https://github.com/qiime2/distributions/pull/367 - installed this env locally and tests pass.