### PR TITLE
Adding qmin, qminout, qmax and qmaxout options to merge-pairs

### DIFF
--- a/q2_vsearch/_merge_pairs.py
+++ b/q2_vsearch/_merge_pairs.py
@@ -29,7 +29,11 @@ _mp_defaults = {
     'minmergelen': None,
     'maxmergelen': None,
     'maxee': None,
-    'threads': 1
+    'threads': 1,
+    'qmin': 0,
+    'qminout': 0,
+    'qmax' : 41,
+    'qmaxout': 41,
 }
 
 
@@ -45,13 +49,18 @@ def merge_pairs(
     maxmergelen: int = _mp_defaults['maxmergelen'],
     maxee: float = _mp_defaults['maxee'],
     threads: int = _mp_defaults['threads'],
+    qmin: int = _mp_defaults['qmin'],
+    qminout: int = _mp_defaults['qminout'],
+    qmax: int = _mp_defaults['qmax'],
+    qmaxout: int = _mp_defaults['qmaxout'],
 ) -> (
     SingleLanePerSampleSingleEndFastqDirFmt,
     SingleLanePerSamplePairedEndFastqDirFmt
 ):
     _, merged, unmerged = _merge_pairs_w_command_output(
         demultiplexed_seqs, truncqual, minlen, maxns, allowmergestagger,
-        minovlen, maxdiffs, minmergelen, maxmergelen, maxee, threads
+        minovlen, maxdiffs, minmergelen, maxmergelen, maxee, threads,
+        qmin, qminout, qmax, qmaxout
     )
 
     return merged, unmerged
@@ -69,6 +78,10 @@ def _merge_pairs_w_command_output(
     maxmergelen: int = _mp_defaults['maxmergelen'],
     maxee: float = _mp_defaults['maxee'],
     threads: int = _mp_defaults['threads'],
+    qmin: int = _mp_defaults['qmin'],
+    qminout: int = _mp_defaults['qminout'],
+    qmax: int = _mp_defaults['qmax'],
+    qmaxout: int = _mp_defaults['qmaxout'],
 ) -> (
     List[str],
     SingleLanePerSampleSingleEndFastqDirFmt,
@@ -141,10 +154,10 @@ def _merge_pairs_w_command_output(
             '--fastq_minlen', str(minlen),
             '--fastq_minovlen', str(minovlen),
             '--fastq_maxdiffs', str(maxdiffs),
-            '--fastq_qmin', '0',
-            '--fastq_qminout', '0',
-            '--fastq_qmax', '41',
-            '--fastq_qmaxout', '41',
+            '--fastq_qmin', str(qmin),
+            '--fastq_qminout', str(qminout),
+            '--fastq_qmax', str(qmax),
+            '--fastq_qmaxout', str(qmaxout),
             '--fasta_width', '0'
         ]
         if truncqual is not None:

--- a/q2_vsearch/_merge_pairs.py
+++ b/q2_vsearch/_merge_pairs.py
@@ -32,7 +32,7 @@ _mp_defaults = {
     'threads': 1,
     'qmin': 0,
     'qminout': 0,
-    'qmax' : 41,
+    'qmax': 41,
     'qmaxout': 41,
 }
 

--- a/q2_vsearch/plugin_setup.py
+++ b/q2_vsearch/plugin_setup.py
@@ -319,10 +319,12 @@ plugin.methods.register_function(
                   'to be retained.'),
         'threads': ('The number of threads to use for computation. Does '
                     'not scale much past 4 threads.'),
-        'qmin': 'Minimun quality score accepted when reading FASTQ files',
-        'qminout': 'Minimum quality score used when writing FASTQ file',
-        'qmax': 'Maximum quality score accepted when reading FASTQ files',
-        'qmaxout': 'Maximum quality score used when writing FASTQ file',
+        'qmin': 'Minimum quality score accepted when reading FASTQ files.',
+        'qminout': ('Minimum quality score used when writing FASTQ files. '
+                    'Only applies to overlap region.'),
+        'qmax': 'Maximum quality score accepted when reading FASTQ files.',
+        'qmaxout': ('Maximum quality score used when writing FASTQ files. '
+                    'Only applies to overlap region.'),
     },
     output_descriptions={
         'merged_sequences': 'The merged sequences.',

--- a/q2_vsearch/plugin_setup.py
+++ b/q2_vsearch/plugin_setup.py
@@ -320,9 +320,9 @@ plugin.methods.register_function(
         'threads': ('The number of threads to use for computation. Does '
                     'not scale much past 4 threads.'),
         'qmin' : 'Minimun quality score accepted when reading FASTQ files',
-        'qminout': 'Minimum quality score used when writing FASTQ file'
+        'qminout': 'Minimum quality score used when writing FASTQ file',
         'qmax' : 'Maximum quality score accepted when reading FASTQ files',
-        'qmaxout': 'Maximum quality score used when writing FASTQ file'
+        'qmaxout': 'Maximum quality score used when writing FASTQ file',
     },
     output_descriptions={
         'merged_sequences': 'The merged sequences.',

--- a/q2_vsearch/plugin_setup.py
+++ b/q2_vsearch/plugin_setup.py
@@ -288,6 +288,10 @@ plugin.methods.register_function(
         'maxmergelen': qiime2.plugin.Int % qiime2.plugin.Range(0, None),
         'maxee': qiime2.plugin.Float % qiime2.plugin.Range(0., None),
         'threads': qiime2.plugin.Threads,
+        'qmin': qiime2.plugin.Int % qiime2.plugin.Range(0, None),
+        'qminout': qiime2.plugin.Int % qiime2.plugin.Range(0, None),
+        'qmax': qiime2.plugin.Int % qiime2.plugin.Range(0, None),
+        'qmaxout': qiime2.plugin.Int % qiime2.plugin.Range(0, None),
     },
     outputs=[
         ('merged_sequences', SampleData[JoinedSequencesWithQuality]),
@@ -314,7 +318,11 @@ plugin.methods.register_function(
         'maxee': ('Maximum number of expected errors in the merged read '
                   'to be retained.'),
         'threads': ('The number of threads to use for computation. Does '
-                    'not scale much past 4 threads.')
+                    'not scale much past 4 threads.'),
+        'qmin' : 'Minimun quality score accepted when reading FASTQ files',
+        'qminout': 'Minimum quality score used when writing FASTQ file'
+        'qmax' : 'Maximum quality score accepted when reading FASTQ files',
+        'qmaxout': 'Maximum quality score used when writing FASTQ file'
     },
     output_descriptions={
         'merged_sequences': 'The merged sequences.',

--- a/q2_vsearch/plugin_setup.py
+++ b/q2_vsearch/plugin_setup.py
@@ -319,9 +319,9 @@ plugin.methods.register_function(
                   'to be retained.'),
         'threads': ('The number of threads to use for computation. Does '
                     'not scale much past 4 threads.'),
-        'qmin' : 'Minimun quality score accepted when reading FASTQ files',
+        'qmin': 'Minimun quality score accepted when reading FASTQ files',
         'qminout': 'Minimum quality score used when writing FASTQ file',
-        'qmax' : 'Maximum quality score accepted when reading FASTQ files',
+        'qmax': 'Maximum quality score accepted when reading FASTQ files',
         'qmaxout': 'Maximum quality score used when writing FASTQ file',
     },
     output_descriptions={

--- a/q2_vsearch/tests/test_merge_pairs.py
+++ b/q2_vsearch/tests/test_merge_pairs.py
@@ -337,7 +337,7 @@ class MergePairsTests(TestPluginBase):
     def test_merge_pairs_alt_qmin(self):
         with redirected_stdio(stderr=os.devnull):
             cmd, obs, _ = _merge_pairs_w_command_output(
-                self.input_seqs, qmin=10)
+                self.input_seqs, qmin=1)
 
         # sanity check the output
         self._test_manifest(obs)
@@ -345,12 +345,12 @@ class MergePairsTests(TestPluginBase):
         self.assertEqual(len(output_fastqs), 3)
 
         # confirm altered parameter was passed to vsearch
-        self.assertTrue('--fastq_qmin 10' in ' '.join(cmd))
+        self.assertTrue('--fastq_qmin 1' in ' '.join(cmd))
 
     def test_merge_pairs_alt_qminout(self):
         with redirected_stdio(stderr=os.devnull):
             cmd, obs, _ = _merge_pairs_w_command_output(
-                self.input_seqs, qminout=10)
+                self.input_seqs, qminout=1)
 
         # sanity check the output
         self._test_manifest(obs)
@@ -358,7 +358,20 @@ class MergePairsTests(TestPluginBase):
         self.assertEqual(len(output_fastqs), 3)
 
         # confirm altered parameter was passed to vsearch
-        self.assertTrue('--fastq_qminout 10' in ' '.join(cmd))
+        self.assertTrue('--fastq_qminout 1' in ' '.join(cmd))
+
+    def test_merge_pairs_alt_qmax(self):
+        with redirected_stdio(stderr=os.devnull):
+            cmd, obs, _ = _merge_pairs_w_command_output(
+                self.input_seqs, qmax=50)
+
+        # sanity check the output
+        self._test_manifest(obs)
+        output_fastqs = list(obs.sequences.iter_views(FastqGzFormat))
+        self.assertEqual(len(output_fastqs), 3)
+
+        # confirm altered parameter was passed to vsearch
+        self.assertTrue('--fastq_qmax 50' in ' '.join(cmd))
 
     def test_merge_pairs_alt_qmaxout(self):
         with redirected_stdio(stderr=os.devnull):

--- a/q2_vsearch/tests/test_merge_pairs.py
+++ b/q2_vsearch/tests/test_merge_pairs.py
@@ -333,3 +333,42 @@ class MergePairsTests(TestPluginBase):
 
         # confirm altered parameter was passed to vsearch
         self.assertTrue('--threads 2' in ' '.join(cmd))
+
+    def test_merge_pairs_alt_qmin(self):
+        with redirected_stdio(stderr=os.devnull):
+            cmd, obs, _ = _merge_pairs_w_command_output(
+                self.input_seqs, qmin=10)
+
+        # sanity check the output
+        self._test_manifest(obs)
+        output_fastqs = list(obs.sequences.iter_views(FastqGzFormat))
+        self.assertEqual(len(output_fastqs), 3)
+
+        # confirm altered parameter was passed to vsearch
+        self.assertTrue('--fastq_qmin 10' in ' '.join(cmd))
+
+    def test_merge_pairs_alt_qminout(self):
+        with redirected_stdio(stderr=os.devnull):
+            cmd, obs, _ = _merge_pairs_w_command_output(
+                self.input_seqs, qminout=10)
+
+        # sanity check the output
+        self._test_manifest(obs)
+        output_fastqs = list(obs.sequences.iter_views(FastqGzFormat))
+        self.assertEqual(len(output_fastqs), 3)
+
+        # confirm altered parameter was passed to vsearch
+        self.assertTrue('--fastq_qminout 10' in ' '.join(cmd))
+
+    def test_merge_pairs_alt_qmaxout(self):
+        with redirected_stdio(stderr=os.devnull):
+            cmd, obs, _ = _merge_pairs_w_command_output(
+                self.input_seqs, qmaxout=50)
+
+        # sanity check the output
+        self._test_manifest(obs)
+        output_fastqs = list(obs.sequences.iter_views(FastqGzFormat))
+        self.assertEqual(len(output_fastqs), 3)
+
+        # confirm altered parameter was passed to vsearch
+        self.assertTrue('--fastq_qmaxout 50' in ' '.join(cmd))


### PR DESCRIPTION
Hi,
The reads fastq quality values for the `merge-pairs` command are hardcoded at 0 for qmin and qminout and 41 for qmax and qmaxout.
However, new sequencing companies, such as AVITI, release fastq reads with qualities above 41 (e.g., 45).
This pull request's goal is to allow the user to modify these parameters, keeping the defaults at 0 and 41.
This addresses this issue

https://github.com/qiime2/q2-vsearch/issues/109

and is related to this forum post

https://forum.qiime2.org/t/plugin-error-from-itsxpress-with-aviti-data-fastq-quality-value-45-above-qmax-41/31342
